### PR TITLE
Update react/event-loop from ^0.4 to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "react/event-loop": "^0.4",
+        "react/event-loop": "^1.0",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/guzzle": "^6.2"
     },

--- a/example/simple_query.php
+++ b/example/simple_query.php
@@ -9,7 +9,7 @@ use function Productsup\GuzzleReactBridge\run;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-run(function ($loop) use ($genFn) {
+run(function ($loop) {
     // Logger to show pretty messages with timestamps.
     $logger = new Logger('default');
     $logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));

--- a/src/CurlMultiHandler.php
+++ b/src/CurlMultiHandler.php
@@ -54,7 +54,7 @@ class CurlMultiHandler extends BaseCurlMultiHandler
 
         // Deactive timer if there are no more active requests.
         if (!$this->activeRequests && $this->timer) {
-            $this->timer->cancel();
+            $this->loop->cancelTimer($this->timer);
             // Don't use unset(), it completely removes property from the object, so next access will be handled by
             // parent's __get()!
             $this->timer = null;

--- a/src/CurlMultiHandler.php
+++ b/src/CurlMultiHandler.php
@@ -5,7 +5,7 @@ namespace Productsup\GuzzleReactBridge;
 use GuzzleHttp\Handler\CurlMultiHandler as BaseCurlMultiHandler;
 use Psr\Http\Message\RequestInterface;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 
 class CurlMultiHandler extends BaseCurlMultiHandler
 {

--- a/src/ReactTaskQueue.php
+++ b/src/ReactTaskQueue.php
@@ -24,6 +24,6 @@ class ReactTaskQueue extends TaskQueue
     {
         parent::add($task);
 
-        $this->loop->nextTick([$this, 'run']);
+        $this->loop->futureTick([$this, 'run']);
     }
 }

--- a/src/Throttler.php
+++ b/src/Throttler.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 
 /**
  * Abstract throttler for any async actions (that produce promises)

--- a/src/Throttler.php
+++ b/src/Throttler.php
@@ -151,7 +151,7 @@ class Throttler
     {
         // Nothing to do. Remove the timer, if there is one...
         if (!$this->activeCalls && !count($this->queue) && $this->timer) {
-            $this->timer->cancel();
+            $this->loop->cancelTimer($this->timer);
             // Don't use unset(), it completely removes property from the object!
             $this->timer = null;
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,9 @@ function run(callable $action)
 
     \GuzzleHttp\Promise\queue(new ReactTaskQueue($loop));
 
-    $loop->nextTick($action);
+    $loop->futureTick(function() use ($loop, $action){
+        $action($loop);
+    });
 
     $loop->run();
 }
@@ -51,7 +53,7 @@ function run_coroutine_fn(callable $coroutine)
     /** @var \Exception $globalError */
     $globalError = null;
 
-    $loop->nextTick(function () use ($coroutineFn, &$globalResult, &$globalError) {
+    $loop->futureTick(function () use ($coroutineFn, &$globalResult, &$globalError) {
         $coroutineInvocation = coroutine($coroutineFn)
             ->then(function ($result) use (&$globalResult) {
                 return $globalResult = $result;


### PR DESCRIPTION
Hi Alexey, 

this PR updates react/event-loop to the first stable release.

The examples work as before, my use cases too. 

Thanks for this package, by the way. 

Best